### PR TITLE
PR of [cloudrun_deploy] Allowing public access

### DIFF
--- a/scripts/cloudrun_deploy.sh
+++ b/scripts/cloudrun_deploy.sh
@@ -47,6 +47,12 @@ for service in $SERVICES; do
     --min-instances 1 \
     --set-env-vars "${ENV_VARS}"
 
+  # Allowing public (unauthenticated) access to Cloud Run services
+  gcloud run services add-iam-policy-binding ${service} \
+  --member="allUsers" \
+  --role="roles/run.invoker"
+
   # Print Cloud Run URL
   gcloud run services describe ${service} --format 'value(status.url)'
 done
+


### PR DESCRIPTION
Allowing public (unauthenticated) access to Cloud Run services.

I deployed Sandcastle to a new environment and realized I had forgotten to setup unauthenticated access to Cloud Run Services